### PR TITLE
added mvn clean compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ If using GitHub Packages (only needed if not yet in Maven Central):
 You can run directly with Maven:
 
 ```bash
+mvn clean compile
 mvn exec:java -Dexec.mainClass=io.spicelabs.ginger.Ginger \
   -Dexec.args="--jwt path/to/spice-pass.jwt --adg path/to/adg-directory"
 ```
@@ -58,6 +59,7 @@ mvn exec:java -Dexec.mainClass=io.spicelabs.ginger.Ginger \
 Or for deployment events:
 
 ```bash
+mvn clean compile
 mvn exec:java -Dexec.mainClass=io.spicelabs.ginger.Ginger \
   -Dexec.args="--jwt path/to/spice-pass.jwt --deployment-events events.json"
 ```


### PR DESCRIPTION
Add `the mvn clean compile` command to the run with Maven section. This is probably something that the most basic software developer would know to do. However, in case someone as clueless as me tries to run ginger-j this will help. 