### PR TITLE
Add ADG scan to ginger-j publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,6 +88,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Index and upload ADG
+        uses: spice-labs-inc/action-spice-labs-cli-scan@v3
+        with:
+          token: ${{ secrets.SPICE_PASS }}
+          input: target
+          tag: ${{ github.event.repository.name }}
+
   notify:
     needs: [publish]
     if: always()


### PR DESCRIPTION
Adds a single step to index and upload ADGs using spice-labs-inc/action-spice-labs-cli-scan@v3.