### PR TITLE
Upgrade actions/checkout and pin runner for Node.js 24 Compatibility

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -27,10 +27,10 @@ jobs:
 
       - name: Test with Maven
         run: mvn --batch-mode --update-snapshots verify
-      
+
     #   - name: Collect Artifacts
     #     run: mkdir staging && cp target/*.jar staging
-      
+
     #   - name: Upload Artifacts
     #     uses: actions/upload-artifact@v4
     #     with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
           channel: "#release-notifications"
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get version from tag (strip 'v')
         id: tag
@@ -99,7 +99,7 @@ jobs:
   notify:
     needs: [publish]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check deployment status
         id: deployment-status


### PR DESCRIPTION
### Summary

Updates both CI workflows to resolve Node.js 20 deprecation warnings on GitHub
Actions runners. `actions/checkout` has been updated to v5 in both files and
the unpinned `ubuntu-latest` runner in the `notify` job has been locked to
`ubuntu-24.04`, ahead of the June 16th enforcement date.

### Changes

- Updated `actions/checkout` from `@v4` to `@v5` in `buildAndTest.yml`
- Updated `actions/checkout` from `@v4` to `@v5` in `publish.yml`
- Pinned `runs-on` from `ubuntu-latest` to `ubuntu-24.04` on the `notify` job
  in `publish.yml`

### Tests

- Push to any branch and confirm the `Build and Test` job completes
  successfully, including Maven build and verify
- Publish a release and confirm the `publish` job completes successfully,
  including publication to Maven Central and GitHub Packages, GPG signing,
  and ADG upload, with a Slack notification to `#release-notifications`
- Confirm the `notify` job fires correctly on both success and failure and
  that Slack thread replies are correctly linked via `thread-ts` and
  `channel-id`

### Impact

No change to build, test, or publish behaviour. Both `actions/setup-java@v4`
steps in the `publish` job were already at the correct version and required no
changes. Note: there is a commented-out `actions/upload-artifact@v4` block in
`buildAndTest.yml` — if this is ever uncommented it should be updated to `@v5`
at that time.

### Ticket

- https://github.com/spice-labs-inc/internal-docs/issues/509