### PR TITLE
Add analyzeStats overload to publishStatus

### DIFF
--- a/src/main/java/io/spicelabs/ginger/DirectUploadService.java
+++ b/src/main/java/io/spicelabs/ginger/DirectUploadService.java
@@ -259,6 +259,28 @@ public class DirectUploadService {
             String message,
             UUID idempotencyKey,
             String userAgent) {
+        publishStatus(baseUrl, jwt, parentId, subJobId, status, progress, message,
+                idempotencyKey, userAgent, null);
+    }
+
+    /**
+     * Variant of {@link #publishStatus(String, String, UUID, UUID, String, Integer, String,
+     * UUID, String)} that additionally attaches an {@code analyzeStats} object to the body.
+     * Intended for the terminal ANALYZE status post: the caller reports what the analyzer
+     * encountered vs what it processed so the server can detect silent truncation. Servers
+     * that predate the field ignore it.
+     */
+    public void publishStatus(
+            String baseUrl,
+            String jwt,
+            UUID parentId,
+            UUID subJobId,
+            String status,
+            Integer progress,
+            String message,
+            UUID idempotencyKey,
+            String userAgent,
+            Map<String, Object> analyzeStats) {
         if (parentId == null || subJobId == null || status == null) {
             return;
         }
@@ -271,6 +293,9 @@ public class DirectUploadService {
         }
         if (message != null) {
             body.put("message", message);
+        }
+        if (analyzeStats != null && !analyzeStats.isEmpty()) {
+            body.put("analyzeStats", analyzeStats);
         }
         String jsonBody;
         try {

--- a/src/main/java/io/spicelabs/ginger/Ginger.java
+++ b/src/main/java/io/spicelabs/ginger/Ginger.java
@@ -204,6 +204,17 @@ public class Ginger implements Callable<Integer> {
    * progress publish can never stall or fail the surrounding work.
    */
   public void publishStatus(UUID subJobId, String status, Integer progress, String message) {
+    publishStatus(subJobId, status, progress, message, null);
+  }
+
+  /**
+   * Variant of {@link #publishStatus(UUID, String, Integer, String)} that additionally
+   * attaches an {@code analyzeStats} object to the status body. Meant for the terminal
+   * ANALYZE post: counts of what the analyzer encountered vs processed, so the server can
+   * detect silent truncation. Servers that predate the field ignore it.
+   */
+  public void publishStatus(UUID subJobId, String status, Integer progress, String message,
+      Map<String, Object> analyzeStats) {
     if (parentId == null || subJobId == null || status == null) {
       return;
     }
@@ -218,7 +229,8 @@ public class Ginger implements Callable<Integer> {
       return;
     }
     new DirectUploadService().publishStatus(
-        server, token, parentId, subJobId, status, progress, message, idempotencyKey, userAgent);
+        server, token, parentId, subJobId, status, progress, message, idempotencyKey, userAgent,
+        analyzeStats);
   }
 
   /**

--- a/src/test/java/io/spicelabs/ginger/DirectUploadServiceTest.java
+++ b/src/test/java/io/spicelabs/ginger/DirectUploadServiceTest.java
@@ -10,6 +10,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -464,6 +465,50 @@ class DirectUploadServiceTest {
         assertTrue(body.contains("\"subJobId\":\"" + subJobId + "\""));
         assertTrue(body.contains("\"status\":\"RUNNING\""));
         assertTrue(body.contains("\"progress\":42"));
+    }
+
+    @Test
+    void publishStatus_includesAnalyzeStatsWhenProvided() throws Exception {
+        mockServer.enqueue(new MockResponse().setResponseCode(204));
+
+        UUID parentId = UUID.randomUUID();
+        service.publishStatus(
+                mockServer.url("/api/global/v1/bundle/upload").toString(),
+                "jwt",
+                parentId,
+                UUID.randomUUID(),
+                "COMPLETED",
+                100,
+                "Analysis complete",
+                UUID.randomUUID(),
+                "spice-labs-cli/test",
+                Map.of("filesEncountered", 12, "bytesEncountered", 3456));
+
+        RecordedRequest req = mockServer.takeRequest();
+        assertEquals("/api/global/v1/surveys/" + parentId + "/status", req.getPath());
+        String body = req.getBody().readUtf8();
+        assertTrue(body.contains("\"analyzeStats\""));
+        assertTrue(body.contains("\"filesEncountered\":12"));
+        assertTrue(body.contains("\"bytesEncountered\":3456"));
+    }
+
+    @Test
+    void publishStatus_omitsAnalyzeStatsWhenAbsent() throws Exception {
+        mockServer.enqueue(new MockResponse().setResponseCode(204));
+
+        service.publishStatus(
+                mockServer.url("/api/global/v1/bundle/upload").toString(),
+                "jwt",
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "RUNNING",
+                10,
+                null,
+                UUID.randomUUID(),
+                null);
+
+        RecordedRequest req = mockServer.takeRequest();
+        assertFalse(req.getBody().readUtf8().contains("analyzeStats"));
     }
 
     @Test


### PR DESCRIPTION
Adds an overload of `publishStatus` (on `Ginger` and `DirectUploadService`) that attaches an optional `analyzeStats` JSON object to the `POST /surveys/{parentId}/status` body. Callers use it on the terminal ANALYZE status post to report what the analyzer encountered vs what it processed, so the server can detect a scan that exited 0 after seeing only part of its input.

- Existing signatures are unchanged and delegate with no stats.
- The field is omitted when null or empty; servers that predate it ignore the extra key.
- Covered by DirectUploadServiceTest: body includes `analyzeStats` when provided, omits it otherwise.
